### PR TITLE
fix: group dependencies for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev:
+        dependency-type: "development"
+      prod:
+        dependency-type: "production"


### PR DESCRIPTION
Group dependencies for dependabot